### PR TITLE
Refactor balancer - create candidates outside of initializer

### DIFF
--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -40,7 +40,7 @@ module Multidb
 
       if @default_configuration
 
-        create_dbs(@default_configuration.raw_configuration[:databases] || {})
+        append(@default_configuration.raw_configuration[:databases] || {})
 
         if @default_configuration.raw_configuration.include?(:fallback)
           @fallback = @default_configuration.raw_configuration[:fallback]
@@ -56,11 +56,11 @@ module Multidb
       end
     end
     
-    def create_dbs(databases)
+    def append(databases)
       databases.each_pair do |name, config|
         configs = config.is_a?(Array) ? config : [config]
         configs.each do |config|
-          candidate = Candidate.new(@default_configuration.default_adapater.merge(config))
+          candidate = Candidate.new(@default_configuration.default_adapter.merge(config))
           @candidates[name] ||= []
           @candidates[name].push(candidate)
         end

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -26,6 +26,23 @@ describe 'Multidb.balancer' do
 
       Multidb.balancer.current_connection.should eq conn
     end
+  
+    context 'with additional configurations' do
+      before do
+        additional_configuration = {slave4: { database: 'spec/test-slave4.sqlite' }}
+        Multidb.balancer.append(additional_configuration)
+      end
+
+      it 'makes the new database available' do
+        Multidb.use(:slave4) do
+          conn = ActiveRecord::Base.connection
+          conn.should eq Multidb.balancer.current_connection
+          list = conn.execute('pragma database_list')
+          list.length.should eq 1
+          File.basename(list[0]['file']).should eq 'test-slave4.sqlite'
+        end
+      end
+    end
   end
 
   describe '#use' do


### PR DESCRIPTION
Any thoughts or objections to a refactor like this? I have the (probably odd) use case of needing to spin up database instances dynamically


Adds flexibility so that candidates can be added dynamically post-facto
i.e:
    #  Multidb.balancer.append({'simulation-123': {database: "file://:simulation.123.db:?mode=memory"}})