### PR TITLE
fix Rails > 3.2.4 and ENV['DATABASE_URL']

### DIFF
--- a/lib/multidb/model_extensions.rb
+++ b/lib/multidb/model_extensions.rb
@@ -12,7 +12,7 @@ module Multidb
     end
 
     module ClassMethods
-      def establish_connection_with_multidb(spec = nil)
+      def establish_connection_with_multidb(spec = ENV["DATABASE_URL"])
         establish_connection_without_multidb(spec)
         Multidb.init(connection_pool.spec.config)
       end


### PR DESCRIPTION
 The prototype of establish_connection has been changed since 3.2.1  to
```
def self.establish_connection(spec = ENV["DATABASE_URL"])
```
http://apidock.com/rails/v3.2.1/ActiveRecord/Base/establish_connection/class

Without this it crashes on Heroku because it has ENV['DATABASE_URL'] set.

