### PR TITLE
Annotate logs with current connection name

### DIFF
--- a/lib/multidb.rb
+++ b/lib/multidb.rb
@@ -6,5 +6,6 @@ require 'active_support/core_ext/module/aliasing'
 
 require_relative 'multidb/configuration'
 require_relative 'multidb/model_extensions'
+require_relative 'multidb/log_subscriber'
 require_relative 'multidb/balancer'
 require_relative 'multidb/version'

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -82,15 +82,19 @@ module Multidb
           candidate.connection do |connection|
             previous_connection, Thread.current[:multidb_connection] =
               Thread.current[:multidb_connection], connection
+            previous_connection_name, Thread.current[:multidb_connection_name] =
+              Thread.current[:multidb_connection_name], name
             begin
               result = yield
             ensure
               Thread.current[:multidb_connection] = previous_connection
+              Thread.current[:multidb_connection_name] = previous_connection_name
             end
             result
           end
         else
           result = Thread.current[:multidb_connection] = candidate.connection
+          Thread.current[:multidb_connection_name] = name
         end
       end
       result
@@ -100,8 +104,12 @@ module Multidb
       Thread.current[:multidb_connection] || @default_candidate.connection
     end
 
+    def current_connection_name
+      Thread.current[:multidb_connection_name]
+    end
+
     class << self
-      delegate :use, :current_connection, :disconnect!, to: :balancer
+      delegate :use, :current_connection, :current_connection_name, :disconnect!, to: :balancer
 
       def use(name, &block)
         Multidb.balancer.use(name, &block)
@@ -109,6 +117,10 @@ module Multidb
 
       def current_connection
         Multidb.balancer.current_connection
+      end
+
+      def current_connection_name
+        Multidb.balancer.current_connection_name
       end
 
       def disconnect!

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -80,32 +80,41 @@ module Multidb
       get(name) do |candidate|
         if block_given?
           candidate.connection do |connection|
-            previous_connection, Thread.current[:multidb_connection] =
-              Thread.current[:multidb_connection], connection
-            previous_connection_name, Thread.current[:multidb_connection_name] =
-              Thread.current[:multidb_connection_name], name
+            previous_configuration = Thread.current[:multidb]
+            Thread.current[:multidb] = {
+              connection: connection,
+              connection_name: name
+            }
             begin
               result = yield
             ensure
-              Thread.current[:multidb_connection] = previous_connection
-              Thread.current[:multidb_connection_name] = previous_connection_name
+              Thread.current[:multidb] = previous_configuration
             end
             result
           end
         else
-          result = Thread.current[:multidb_connection] = candidate.connection
-          Thread.current[:multidb_connection_name] = name
+          Thread.current[:multidb] = {
+            connection: candidate.connection,
+            connection_name: name
+          }
+          result = candidate.connection
         end
       end
       result
     end
 
     def current_connection
-      Thread.current[:multidb_connection] || @default_candidate.connection
+      if Thread.current[:multidb]
+        Thread.current[:multidb][:connection]
+      else
+        @default_candidate.connection
+      end
     end
 
     def current_connection_name
-      Thread.current[:multidb_connection_name]
+      if Thread.current[:multidb]
+        Thread.current[:multidb][:connection_name]
+      end
     end
 
     class << self

--- a/lib/multidb/log_subscriber.rb
+++ b/lib/multidb/log_subscriber.rb
@@ -1,0 +1,19 @@
+module Multidb
+  module LogSubscriber
+    extend ActiveSupport::Concern
+
+    included do
+      def debug_with_multidb(msg)
+        if name = Multidb.balancer.current_connection_name
+          db = color("[DB: #{name}]", ActiveSupport::LogSubscriber::GREEN, true)
+          debug_without_multidb(db + msg)
+        else
+          debug_without_multidb(msg)
+        end
+      end
+      alias_method_chain :debug, :multidb
+    end
+  end
+end
+
+ActiveRecord::LogSubscriber.send(:include, Multidb::LogSubscriber)


### PR DESCRIPTION
It works by storing the connection name in `Thread.current[:multidb_connection_name]` and alias-chaining the `debug` method of `ActiveRecord::LogSubscriber` to annotate the log message (like the Octopus gem).
