### PR TITLE
Execute the relation in the context of the current db

### DIFF
--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -91,6 +91,7 @@ module Multidb
               Thread.current[:multidb_connection], connection
             begin
               result = yield
+              result = result.to_a if result.is_a?(ActiveRecord::Relation)
             ensure
               Thread.current[:multidb_connection] = previous_connection
             end

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -82,6 +82,16 @@ describe 'Multidb.balancer' do
         end
       end
 
+      it 'returns results instead of relation' do
+        class FooBar < ActiveRecord::Base; end
+        res = Multidb.use(:slave1) do
+          ActiveRecord::Migration.verbose = false
+          ActiveRecord::Schema.define(version: 1) { create_table :foo_bars }
+          FooBar.where(id: 42)
+        end
+        res.should eq []
+      end
+
       it 'returns supports nested slave connection' do
         Multidb.use(:slave1) do
           Multidb.use(:slave2) do


### PR DESCRIPTION
If code, such as `Model.where(foo: true)`, was performed then the query won't actually be performed because that is simply an ActiveRecord::Relation.  This change forces the Relation to be executed in the context of the `use` call. See https://github.com/atombender/multidb/issues/7 

Note: Using `to_a` so that the code is compatible with earlier versions of ActiveRecord. I am using 3.2 and `load` isn't available.
