### PR TITLE
Add support for database aliases

### DIFF
--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activesupport', '>= 3.0'
-  s.add_runtime_dependency 'activerecord', '>= 3.0'
+  s.add_runtime_dependency 'activesupport', '~> 3'
+  s.add_runtime_dependency 'activerecord', '~> 3'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -55,11 +55,16 @@ module Multidb
         end
       end
     end
-    
+
     def append(databases)
       databases.each_pair do |name, config|
         configs = config.is_a?(Array) ? config : [config]
         configs.each do |config|
+          if config["alias"]
+            @candidates[name] = @candidates[config["alias"]]
+            next
+          end
+
           candidate = Candidate.new(@default_configuration.default_adapter.merge(config))
           @candidates[name] ||= []
           @candidates[name].push(candidate)

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -84,6 +84,9 @@ module Multidb
       raise ArgumentError, "No such database connection '#{name}'" if candidates.empty?
       candidate = candidates.respond_to?(:sample) ?
         candidates.sample : candidates[rand(candidates.length)]
+      spec = candidate.connection_pool.spec
+      spec.config[:shard] = name
+      candidate.connection_pool.instance_variable_set(:@spec, spec)
       block_given? ? yield(candidate) : candidate
     end
 

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -112,6 +112,11 @@ describe 'Multidb.balancer' do
         end
       end
 
+      it "returns the parent connection for aliases" do
+        Multidb.use(:slave1).should_not eq Multidb.use(:slave4)
+        Multidb.use(:slave2).should eq Multidb.use(:slave4)
+      end
+
       it 'returns random candidate' do
         names = []
         100.times do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -14,6 +14,10 @@ multidb:
     slave3:
       - database: spec/test-slave3-1.sqlite
       - database: spec/test-slave3-2.sqlite
+    slave4:
+      database: spec/test-slave2.sqlite
+      alias: slave2
+      
 end
   end
 


### PR DESCRIPTION
We have been using this in production for a while (Ruby 1.9.3, Rails 3.2.22.5) at a very large scale and everything works fine.

We are in the process of upgrading our infrastructure + getting rid of local forks, this has been hanging there for too long.