### PR TITLE
Rails 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 \.DS_Store
 *.sqlite
 Gemfile.lock
+.rspec

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 \.DS_Store
 *.sqlite
 Gemfile.lock
+Gemfile.local
 .rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
-rvm:
-  - 1.9.3
-  - 2.0
+sudo: false
+language: ruby
+
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 2.2
+      gemfile: gemfiles/activerecord40.gemfile
+    - rvm: 2.4.3
+      gemfile: gemfiles/activerecord42.gemfile
+    - rvm: 2.5.0
+      gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,3 @@ local_gemfile = "Gemfile.local"
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
 end
-
-group :test do
-  # For travis-ci.org
-  gem "rake"
-end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,12 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in ar-multidb.gemspec
 gemspec
 
+local_gemfile = "Gemfile.local"
+
+if File.exist?(local_gemfile)
+  eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
+end
+
 group :test do
   # For travis-ci.org
   gem "rake"

--- a/README.markdown
+++ b/README.markdown
@@ -14,8 +14,8 @@ Randomized balancing of multiple connections within a group is supported. In the
 
 ## Requirements
 
-* Ruby 1.9.3 or later.
-* ActiveRecord 3.0 or later. (Earlier versions can use the gem version 0.1.10.)
+* Ruby 2.2 or later.
+* ActiveRecord 4.0 or later. (Earlier versions can use the gem version 0.1.13 for Rails 3.2 and 0.1.10 for older version)
 
 ## Comparison to other ActiveRecord extensions
 

--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activesupport', '~> 4.2'
-  s.add_runtime_dependency 'activerecord', '~> 4.2'
+  s.add_runtime_dependency 'activesupport', '>= 4.2', '<= 6.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.2', '<= 6.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'

--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activesupport', '>= 3.0', '< 5.0'
-  s.add_runtime_dependency 'activerecord', '>= 3.0', '< 5.0'
+  s.add_runtime_dependency 'activesupport', '~> 4.2'
+  s.add_runtime_dependency 'activerecord', '~> 4.2'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'

--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'activesupport', '>= 4.2', '<= 6.0'
-  s.add_runtime_dependency 'activerecord', '>= 4.2', '<= 6.0'
+  s.add_runtime_dependency 'activesupport', '>= 4.0', '<= 6.0'
+  s.add_runtime_dependency 'activerecord', '>= 4.0', '<= 6.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'rake'
 end

--- a/gemfiles/activerecord40.gemfile
+++ b/gemfiles/activerecord40.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 4.0.0'
+
+gemspec path: '..'

--- a/gemfiles/activerecord42.gemfile
+++ b/gemfiles/activerecord42.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 4.2'
+
+gemspec path: '..'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require_relative 'helpers'
 
 RSpec.configure do |config|
   config.include Helpers
+  config.expect_with(:rspec) { |c| c.syntax = :should }
   config.before :each do
     ActiveRecord::Base.clear_all_connections!
     Multidb.reset!


### PR DESCRIPTION
This PR also drops support for Ruby 1.9 and Rails < 4.

Also, added additional gemfiles for Travis.