### PR TITLE
 Send current connection name to logs and payload

### DIFF
--- a/lib/multidb.rb
+++ b/lib/multidb.rb
@@ -6,5 +6,6 @@ require 'active_support/core_ext/module/aliasing'
 
 require_relative 'multidb/configuration'
 require_relative 'multidb/model_extensions'
+require_relative 'multidb/log_subscriber'
 require_relative 'multidb/balancer'
 require_relative 'multidb/version'

--- a/lib/multidb/log_subscriber.rb
+++ b/lib/multidb/log_subscriber.rb
@@ -1,0 +1,21 @@
+module Multidb
+  module LogSubscriberExtension
+    def sql(event)
+      if name = Multidb.balancer.current_connection_name
+        event.payload[:db_name] = name
+      end
+      super
+    end
+
+    def debug(msg)
+      if name = Multidb.balancer.current_connection_name
+        db = color("[DB: #{name}]", ActiveSupport::LogSubscriber::GREEN, true)
+        super(db + msg)
+      else
+        super
+      end
+    end
+  end
+end
+
+ActiveRecord::LogSubscriber.prepend(Multidb::LogSubscriberExtension)

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -26,6 +26,12 @@ describe 'Multidb.balancer' do
 
       Multidb.balancer.current_connection.should eq conn
     end
+
+    it 'returns default connection name for default connection' do
+      conn = ActiveRecord::Base.connection
+
+      Multidb.balancer.current_connection_name.should eq :default
+    end
   
     context 'with additional configurations' do
       before do
@@ -40,6 +46,12 @@ describe 'Multidb.balancer' do
           list = conn.execute('pragma database_list')
           list.length.should eq 1
           File.basename(list[0]['file']).should eq 'test-slave4.sqlite'
+        end
+      end
+
+      it 'returns the connection name' do
+        Multidb.use(:slave4) do
+          Multidb.balancer.current_connection_name.should eq :slave4
         end
       end
     end


### PR DESCRIPTION
This adds the connection name onto the log payload for SQL queries, so that tools like lograge can then pull it off for its own logging.

This was based off of https://github.com/atombender/multidb/pull/11, but with some changes to make things a bit cleaner (like using `prepend`, and adding some specs).
